### PR TITLE
Add missing matches

### DIFF
--- a/2013-14/en.1.json
+++ b/2013-14/en.1.json
@@ -3742,6 +3742,21 @@
         {
           "date": "2014-02-08",
           "team1": {
+            "key": "crystalpalace",
+            "name": "Crystal Palace",
+            "code": "CRY"
+          },
+          "team2": {
+            "key": "westbrom",
+            "name": "West Bromwich Albion",
+            "code": "WBA"
+          },
+          "score1": 3,
+          "score2": 1
+        },
+        {
+          "date": "2014-02-08",
+          "team1": {
             "key": "astonvilla",
             "name": "Aston Villa",
             "code": "AVL"

--- a/2014-15/de.1.json
+++ b/2014-15/de.1.json
@@ -4067,6 +4067,21 @@
         {
           "date": "2015-04-25",
           "team1": {
+            "key": "mainz",
+            "name": "1. FSV Mainz 05",
+            "code": "M05"
+          },
+          "team2": {
+            "key": "schalke",
+            "name": "Schalke 04",
+            "code": "S04"
+          },
+          "score1": 2,
+          "score2": 0
+        },
+        {
+          "date": "2015-04-25",
+          "team1": {
             "key": "koeln",
             "name": "1. FC Köln",
             "code": "KOE"

--- a/2014-15/es.1.json
+++ b/2014-15/es.1.json
@@ -3727,6 +3727,21 @@
         {
           "date": "2015-03-01",
           "team1": {
+            "key": "espanyol",
+            "name": "Espanyol",
+            "code": "ESP"
+          },
+          "team2": {
+            "key": "cordoba",
+            "name": "Córdoba",
+            "code": null
+          },
+          "score1": 1,
+          "score2": 0
+        },
+        {
+          "date": "2015-03-01",
+          "team1": {
             "key": "malaga",
             "name": "Málaga",
             "code": "MAG"

--- a/2014-15/es.1.json
+++ b/2014-15/es.1.json
@@ -3393,6 +3393,21 @@
           },
           "score1": 4,
           "score2": 1
+        },
+        {
+          "date": "2015-02-08",
+          "team1": {
+            "key": "espanyol",
+            "name": "Espanyol",
+            "code": "ESP"
+          },
+          "team2": {
+            "key": "valencia",
+            "name": "Valencia",
+            "code": "VAL"
+          },
+          "score1": 1,
+          "score2": 2
         }
       ]
     },

--- a/2014-15/it.1.json
+++ b/2014-15/it.1.json
@@ -1677,6 +1677,21 @@
         {
           "date": "2014-11-09",
           "team1": {
+            "key": "inter",
+            "name": "Inter",
+            "code": "INT"
+          },
+          "team2": {
+            "key": "hellasverona",
+            "name": "Verona",
+            "code": "HEL"
+          },
+          "score1": 2,
+          "score2": 2
+        },
+        {
+          "date": "2014-11-09",
+          "team1": {
             "key": "roma",
             "name": "Roma",
             "code": "ROM"


### PR DESCRIPTION
Some matches are missing in the generated JSON file, although being in the source files (see individual commits).

This pull request adds the missing matches directly to the JSONized project, since the source data is correct and the error must have happened during processing and ```Note: [..] please do NOT edit the JSON files but the source files in the country repos e.g.:``` is not a feasible solution here

I added kicker.de links to verify the correctness of my changes