### PR TITLE
Add generated football.json files from existing 2026-27 premiership and championship txt data

### DIFF
--- a/2026-27/en.1.json
+++ b/2026-27/en.1.json
@@ -1,0 +1,2665 @@
+{
+  "name": "English Premier League 2026/27",
+  "matches": [
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-21",
+      "time": "20:00",
+      "team1": "Arsenal FC",
+      "team2": "Coventry City FC"
+    },
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-22",
+      "time": "12:30",
+      "team1": "Hull City AFC",
+      "team2": "Manchester United FC"
+    },
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-22",
+      "time": "15:00",
+      "team1": "Ipswich Town FC",
+      "team2": "Sunderland AFC"
+    },
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-22",
+      "time": "15:00",
+      "team1": "Nottingham Forest FC",
+      "team2": "Leeds United FC"
+    },
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-22",
+      "time": "15:00",
+      "team1": "Everton FC",
+      "team2": "Crystal Palace FC"
+    },
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-22",
+      "time": "17:30",
+      "team1": "Brentford FC",
+      "team2": "Tottenham Hotspur FC"
+    },
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-23",
+      "time": "14:00",
+      "team1": "Manchester City FC",
+      "team2": "AFC Bournemouth"
+    },
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-23",
+      "time": "14:00",
+      "team1": "Brighton & Hove Albion FC",
+      "team2": "Aston Villa FC"
+    },
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-23",
+      "time": "16:30",
+      "team1": "Newcastle United FC",
+      "team2": "Liverpool FC"
+    },
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-24",
+      "time": "20:00",
+      "team1": "Fulham FC",
+      "team2": "Chelsea FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Liverpool FC",
+      "team2": "Nottingham Forest FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Manchester United FC",
+      "team2": "Ipswich Town FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Sunderland AFC",
+      "team2": "Fulham FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Crystal Palace FC",
+      "team2": "Manchester City FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Chelsea FC",
+      "team2": "Brighton & Hove Albion FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Aston Villa FC",
+      "team2": "Arsenal FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Tottenham Hotspur FC",
+      "team2": "Newcastle United FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Leeds United FC",
+      "team2": "Brentford FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "AFC Bournemouth",
+      "team2": "Everton FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Coventry City FC",
+      "team2": "Hull City AFC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "Nottingham Forest FC",
+      "team2": "Tottenham Hotspur FC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "Manchester City FC",
+      "team2": "Coventry City FC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "Brighton & Hove Albion FC",
+      "team2": "Leeds United FC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "Brentford FC",
+      "team2": "Sunderland AFC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "Ipswich Town FC",
+      "team2": "Liverpool FC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "Everton FC",
+      "team2": "Manchester United FC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "Fulham FC",
+      "team2": "Crystal Palace FC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "Hull City AFC",
+      "team2": "Aston Villa FC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "Arsenal FC",
+      "team2": "Chelsea FC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "Newcastle United FC",
+      "team2": "AFC Bournemouth"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "Crystal Palace FC",
+      "team2": "Ipswich Town FC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "Liverpool FC",
+      "team2": "Fulham FC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "Aston Villa FC",
+      "team2": "Nottingham Forest FC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "Tottenham Hotspur FC",
+      "team2": "Everton FC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "AFC Bournemouth",
+      "team2": "Brentford FC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "Sunderland AFC",
+      "team2": "Arsenal FC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "Coventry City FC",
+      "team2": "Brighton & Hove Albion FC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "Leeds United FC",
+      "team2": "Newcastle United FC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "Manchester United FC",
+      "team2": "Manchester City FC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "Chelsea FC",
+      "team2": "Hull City AFC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "AFC Bournemouth",
+      "team2": "Liverpool FC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Fulham FC",
+      "team2": "Manchester United FC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Everton FC",
+      "team2": "Ipswich Town FC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Leeds United FC",
+      "team2": "Crystal Palace FC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Brighton & Hove Albion FC",
+      "team2": "Arsenal FC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Tottenham Hotspur FC",
+      "team2": "Aston Villa FC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Newcastle United FC",
+      "team2": "Hull City AFC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Nottingham Forest FC",
+      "team2": "Coventry City FC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Manchester City FC",
+      "team2": "Sunderland AFC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Brentford FC",
+      "team2": "Chelsea FC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "Sunderland AFC",
+      "team2": "Brighton & Hove Albion FC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "Arsenal FC",
+      "team2": "Leeds United FC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "Hull City AFC",
+      "team2": "Everton FC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "Chelsea FC",
+      "team2": "AFC Bournemouth"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "Crystal Palace FC",
+      "team2": "Nottingham Forest FC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "Coventry City FC",
+      "team2": "Newcastle United FC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "Liverpool FC",
+      "team2": "Manchester City FC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "Ipswich Town FC",
+      "team2": "Fulham FC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "Manchester United FC",
+      "team2": "Tottenham Hotspur FC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "Aston Villa FC",
+      "team2": "Brentford FC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "Fulham FC",
+      "team2": "Hull City AFC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "Everton FC",
+      "team2": "Chelsea FC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "AFC Bournemouth",
+      "team2": "Sunderland AFC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "Leeds United FC",
+      "team2": "Manchester United FC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "Tottenham Hotspur FC",
+      "team2": "Coventry City FC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "Newcastle United FC",
+      "team2": "Aston Villa FC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "Nottingham Forest FC",
+      "team2": "Arsenal FC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "Brighton & Hove Albion FC",
+      "team2": "Crystal Palace FC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "Manchester City FC",
+      "team2": "Ipswich Town FC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "Brentford FC",
+      "team2": "Liverpool FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Liverpool FC",
+      "team2": "Brighton & Hove Albion FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Crystal Palace FC",
+      "team2": "Newcastle United FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Aston Villa FC",
+      "team2": "Manchester City FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Manchester United FC",
+      "team2": "AFC Bournemouth"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Arsenal FC",
+      "team2": "Everton FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Chelsea FC",
+      "team2": "Tottenham Hotspur FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Coventry City FC",
+      "team2": "Fulham FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Hull City AFC",
+      "team2": "Brentford FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Ipswich Town FC",
+      "team2": "Nottingham Forest FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Sunderland AFC",
+      "team2": "Leeds United FC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "Newcastle United FC",
+      "team2": "Everton FC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "Manchester City FC",
+      "team2": "Brighton & Hove Albion FC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "AFC Bournemouth",
+      "team2": "Leeds United FC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "Coventry City FC",
+      "team2": "Sunderland AFC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "Chelsea FC",
+      "team2": "Manchester United FC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "Tottenham Hotspur FC",
+      "team2": "Crystal Palace FC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "Aston Villa FC",
+      "team2": "Fulham FC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "Hull City AFC",
+      "team2": "Ipswich Town FC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "Brentford FC",
+      "team2": "Nottingham Forest FC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "Liverpool FC",
+      "team2": "Arsenal FC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Arsenal FC",
+      "team2": "Hull City AFC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Nottingham Forest FC",
+      "team2": "Manchester City FC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Leeds United FC",
+      "team2": "Tottenham Hotspur FC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Fulham FC",
+      "team2": "Newcastle United FC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Everton FC",
+      "team2": "Coventry City FC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Crystal Palace FC",
+      "team2": "Liverpool FC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Sunderland AFC",
+      "team2": "Chelsea FC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Ipswich Town FC",
+      "team2": "AFC Bournemouth"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Brighton & Hove Albion FC",
+      "team2": "Brentford FC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Manchester United FC",
+      "team2": "Aston Villa FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "Chelsea FC",
+      "team2": "Leeds United FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "Manchester City FC",
+      "team2": "Fulham FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "Aston Villa FC",
+      "team2": "Sunderland AFC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "Liverpool FC",
+      "team2": "Manchester United FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "Hull City AFC",
+      "team2": "Brighton & Hove Albion FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "AFC Bournemouth",
+      "team2": "Nottingham Forest FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "Tottenham Hotspur FC",
+      "team2": "Ipswich Town FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "Brentford FC",
+      "team2": "Everton FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "Coventry City FC",
+      "team2": "Crystal Palace FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "Newcastle United FC",
+      "team2": "Arsenal FC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "Leeds United FC",
+      "team2": "Coventry City FC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "Ipswich Town FC",
+      "team2": "Aston Villa FC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "Arsenal FC",
+      "team2": "Manchester City FC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "Manchester United FC",
+      "team2": "Brentford FC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "Everton FC",
+      "team2": "Liverpool FC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "Fulham FC",
+      "team2": "AFC Bournemouth"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "Nottingham Forest FC",
+      "team2": "Chelsea FC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "Brighton & Hove Albion FC",
+      "team2": "Newcastle United FC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "Sunderland AFC",
+      "team2": "Tottenham Hotspur FC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "Crystal Palace FC",
+      "team2": "Hull City AFC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-12-02",
+      "time": "20:00",
+      "team1": "Tottenham Hotspur FC",
+      "team2": "Fulham FC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-12-02",
+      "time": "20:00",
+      "team1": "Liverpool FC",
+      "team2": "Sunderland AFC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-12-02",
+      "time": "20:00",
+      "team1": "Hull City AFC",
+      "team2": "Nottingham Forest FC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-12-02",
+      "time": "20:00",
+      "team1": "Chelsea FC",
+      "team2": "Crystal Palace FC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-12-02",
+      "time": "20:00",
+      "team1": "Aston Villa FC",
+      "team2": "Everton FC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-12-02",
+      "time": "20:00",
+      "team1": "Brentford FC",
+      "team2": "Arsenal FC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-12-02",
+      "time": "20:00",
+      "team1": "Coventry City FC",
+      "team2": "Ipswich Town FC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-12-02",
+      "time": "20:00",
+      "team1": "Manchester City FC",
+      "team2": "Leeds United FC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-12-02",
+      "time": "20:00",
+      "team1": "Newcastle United FC",
+      "team2": "Manchester United FC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-12-02",
+      "time": "20:00",
+      "team1": "AFC Bournemouth",
+      "team2": "Brighton & Hove Albion FC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Tottenham Hotspur FC",
+      "team2": "Arsenal FC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Manchester United FC",
+      "team2": "Coventry City FC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Leeds United FC",
+      "team2": "Ipswich Town FC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Newcastle United FC",
+      "team2": "Sunderland AFC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Chelsea FC",
+      "team2": "Liverpool FC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Brentford FC",
+      "team2": "Manchester City FC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "AFC Bournemouth",
+      "team2": "Hull City AFC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Aston Villa FC",
+      "team2": "Crystal Palace FC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Nottingham Forest FC",
+      "team2": "Brighton & Hove Albion FC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Everton FC",
+      "team2": "Fulham FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Sunderland AFC",
+      "team2": "Nottingham Forest FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Crystal Palace FC",
+      "team2": "Manchester United FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Hull City AFC",
+      "team2": "Tottenham Hotspur FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Brighton & Hove Albion FC",
+      "team2": "Everton FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Ipswich Town FC",
+      "team2": "Newcastle United FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Coventry City FC",
+      "team2": "Aston Villa FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Arsenal FC",
+      "team2": "AFC Bournemouth"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Manchester City FC",
+      "team2": "Chelsea FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Liverpool FC",
+      "team2": "Leeds United FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Fulham FC",
+      "team2": "Brentford FC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "Leeds United FC",
+      "team2": "Fulham FC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "Brighton & Hove Albion FC",
+      "team2": "Ipswich Town FC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "Nottingham Forest FC",
+      "team2": "Everton FC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "Brentford FC",
+      "team2": "Newcastle United FC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "Manchester City FC",
+      "team2": "Hull City AFC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "Sunderland AFC",
+      "team2": "Crystal Palace FC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "AFC Bournemouth",
+      "team2": "Coventry City FC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "Arsenal FC",
+      "team2": "Manchester United FC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "Liverpool FC",
+      "team2": "Tottenham Hotspur FC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "Chelsea FC",
+      "team2": "Aston Villa FC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Aston Villa FC",
+      "team2": "Leeds United FC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Manchester United FC",
+      "team2": "Nottingham Forest FC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Crystal Palace FC",
+      "team2": "Arsenal FC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Everton FC",
+      "team2": "Sunderland AFC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Coventry City FC",
+      "team2": "Chelsea FC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Newcastle United FC",
+      "team2": "Manchester City FC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Fulham FC",
+      "team2": "Brighton & Hove Albion FC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Tottenham Hotspur FC",
+      "team2": "AFC Bournemouth"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Hull City AFC",
+      "team2": "Liverpool FC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Ipswich Town FC",
+      "team2": "Brentford FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-12-30",
+      "time": "20:00",
+      "team1": "Fulham FC",
+      "team2": "Arsenal FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-12-30",
+      "time": "20:00",
+      "team1": "Coventry City FC",
+      "team2": "Brentford FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-12-30",
+      "time": "20:00",
+      "team1": "Aston Villa FC",
+      "team2": "Liverpool FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-12-30",
+      "time": "20:00",
+      "team1": "Newcastle United FC",
+      "team2": "Nottingham Forest FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-12-30",
+      "time": "20:00",
+      "team1": "Hull City AFC",
+      "team2": "Leeds United FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-12-30",
+      "time": "20:00",
+      "team1": "Manchester United FC",
+      "team2": "Sunderland AFC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-12-30",
+      "time": "20:00",
+      "team1": "Ipswich Town FC",
+      "team2": "Chelsea FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-12-30",
+      "time": "20:00",
+      "team1": "Tottenham Hotspur FC",
+      "team2": "Brighton & Hove Albion FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-12-30",
+      "time": "20:00",
+      "team1": "Everton FC",
+      "team2": "Manchester City FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-12-30",
+      "time": "20:00",
+      "team1": "Crystal Palace FC",
+      "team2": "AFC Bournemouth"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2027-01-02",
+      "time": "12:00",
+      "team1": "AFC Bournemouth",
+      "team2": "Aston Villa FC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2027-01-02",
+      "time": "12:00",
+      "team1": "Brentford FC",
+      "team2": "Crystal Palace FC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2027-01-02",
+      "time": "12:00",
+      "team1": "Leeds United FC",
+      "team2": "Everton FC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2027-01-02",
+      "time": "12:00",
+      "team1": "Arsenal FC",
+      "team2": "Ipswich Town FC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2027-01-02",
+      "time": "12:00",
+      "team1": "Sunderland AFC",
+      "team2": "Hull City AFC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2027-01-02",
+      "time": "12:00",
+      "team1": "Liverpool FC",
+      "team2": "Coventry City FC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2027-01-02",
+      "time": "12:00",
+      "team1": "Chelsea FC",
+      "team2": "Newcastle United FC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2027-01-02",
+      "time": "12:00",
+      "team1": "Nottingham Forest FC",
+      "team2": "Fulham FC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2027-01-02",
+      "time": "12:00",
+      "team1": "Brighton & Hove Albion FC",
+      "team2": "Manchester United FC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2027-01-02",
+      "time": "12:00",
+      "team1": "Manchester City FC",
+      "team2": "Tottenham Hotspur FC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2027-01-06",
+      "time": "12:00",
+      "team1": "Arsenal FC",
+      "team2": "Brentford FC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2027-01-06",
+      "time": "12:00",
+      "team1": "Leeds United FC",
+      "team2": "Manchester City FC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2027-01-06",
+      "time": "12:00",
+      "team1": "Manchester United FC",
+      "team2": "Newcastle United FC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2027-01-06",
+      "time": "12:00",
+      "team1": "Brighton & Hove Albion FC",
+      "team2": "AFC Bournemouth"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2027-01-06",
+      "time": "12:00",
+      "team1": "Nottingham Forest FC",
+      "team2": "Hull City AFC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2027-01-06",
+      "time": "12:00",
+      "team1": "Fulham FC",
+      "team2": "Tottenham Hotspur FC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2027-01-06",
+      "time": "12:00",
+      "team1": "Everton FC",
+      "team2": "Aston Villa FC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2027-01-06",
+      "time": "12:00",
+      "team1": "Sunderland AFC",
+      "team2": "Liverpool FC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2027-01-06",
+      "time": "12:00",
+      "team1": "Crystal Palace FC",
+      "team2": "Chelsea FC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2027-01-06",
+      "time": "12:00",
+      "team1": "Ipswich Town FC",
+      "team2": "Coventry City FC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "AFC Bournemouth",
+      "team2": "Ipswich Town FC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "Manchester City FC",
+      "team2": "Nottingham Forest FC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "Chelsea FC",
+      "team2": "Sunderland AFC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "Brentford FC",
+      "team2": "Brighton & Hove Albion FC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "Aston Villa FC",
+      "team2": "Manchester United FC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "Tottenham Hotspur FC",
+      "team2": "Leeds United FC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "Coventry City FC",
+      "team2": "Everton FC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "Liverpool FC",
+      "team2": "Crystal Palace FC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "Hull City AFC",
+      "team2": "Arsenal FC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "Newcastle United FC",
+      "team2": "Fulham FC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Ipswich Town FC",
+      "team2": "Hull City AFC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Everton FC",
+      "team2": "Brentford FC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Sunderland AFC",
+      "team2": "Coventry City FC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Nottingham Forest FC",
+      "team2": "AFC Bournemouth"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Arsenal FC",
+      "team2": "Newcastle United FC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Leeds United FC",
+      "team2": "Chelsea FC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Fulham FC",
+      "team2": "Aston Villa FC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Manchester United FC",
+      "team2": "Liverpool FC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Brighton & Hove Albion FC",
+      "team2": "Manchester City FC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Crystal Palace FC",
+      "team2": "Tottenham Hotspur FC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "Tottenham Hotspur FC",
+      "team2": "Sunderland AFC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "Brentford FC",
+      "team2": "Manchester United FC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "Newcastle United FC",
+      "team2": "Brighton & Hove Albion FC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "Hull City AFC",
+      "team2": "Crystal Palace FC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "Coventry City FC",
+      "team2": "Leeds United FC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "AFC Bournemouth",
+      "team2": "Fulham FC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "Chelsea FC",
+      "team2": "Nottingham Forest FC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "Liverpool FC",
+      "team2": "Everton FC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "Manchester City FC",
+      "team2": "Arsenal FC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "Aston Villa FC",
+      "team2": "Ipswich Town FC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Arsenal FC",
+      "team2": "Liverpool FC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Brighton & Hove Albion FC",
+      "team2": "Hull City AFC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Sunderland AFC",
+      "team2": "Aston Villa FC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Crystal Palace FC",
+      "team2": "Coventry City FC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Ipswich Town FC",
+      "team2": "Tottenham Hotspur FC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Everton FC",
+      "team2": "Newcastle United FC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Fulham FC",
+      "team2": "Manchester City FC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Leeds United FC",
+      "team2": "AFC Bournemouth"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Manchester United FC",
+      "team2": "Chelsea FC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Nottingham Forest FC",
+      "team2": "Brentford FC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-02-10",
+      "time": "12:00",
+      "team1": "Everton FC",
+      "team2": "Leeds United FC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-02-10",
+      "time": "12:00",
+      "team1": "Coventry City FC",
+      "team2": "Liverpool FC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-02-10",
+      "time": "12:00",
+      "team1": "Hull City AFC",
+      "team2": "Sunderland AFC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-02-10",
+      "time": "12:00",
+      "team1": "Aston Villa FC",
+      "team2": "AFC Bournemouth"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-02-10",
+      "time": "12:00",
+      "team1": "Crystal Palace FC",
+      "team2": "Brentford FC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-02-10",
+      "time": "12:00",
+      "team1": "Newcastle United FC",
+      "team2": "Chelsea FC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-02-10",
+      "time": "12:00",
+      "team1": "Fulham FC",
+      "team2": "Nottingham Forest FC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-02-10",
+      "time": "12:00",
+      "team1": "Tottenham Hotspur FC",
+      "team2": "Manchester City FC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-02-10",
+      "time": "12:00",
+      "team1": "Manchester United FC",
+      "team2": "Brighton & Hove Albion FC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-02-10",
+      "time": "12:00",
+      "team1": "Ipswich Town FC",
+      "team2": "Arsenal FC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "Manchester City FC",
+      "team2": "Newcastle United FC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "AFC Bournemouth",
+      "team2": "Crystal Palace FC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "Brentford FC",
+      "team2": "Coventry City FC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "Chelsea FC",
+      "team2": "Ipswich Town FC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "Liverpool FC",
+      "team2": "Hull City AFC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "Arsenal FC",
+      "team2": "Fulham FC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "Nottingham Forest FC",
+      "team2": "Manchester United FC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "Brighton & Hove Albion FC",
+      "team2": "Tottenham Hotspur FC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "Sunderland AFC",
+      "team2": "Everton FC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "Leeds United FC",
+      "team2": "Aston Villa FC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Crystal Palace FC",
+      "team2": "Sunderland AFC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Manchester United FC",
+      "team2": "Arsenal FC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Ipswich Town FC",
+      "team2": "Brighton & Hove Albion FC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Coventry City FC",
+      "team2": "AFC Bournemouth"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Everton FC",
+      "team2": "Nottingham Forest FC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Fulham FC",
+      "team2": "Leeds United FC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Aston Villa FC",
+      "team2": "Chelsea FC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Tottenham Hotspur FC",
+      "team2": "Liverpool FC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Newcastle United FC",
+      "team2": "Brentford FC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Hull City AFC",
+      "team2": "Manchester City FC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-03-03",
+      "time": "12:00",
+      "team1": "Nottingham Forest FC",
+      "team2": "Newcastle United FC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-03-03",
+      "time": "12:00",
+      "team1": "AFC Bournemouth",
+      "team2": "Tottenham Hotspur FC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-03-03",
+      "time": "12:00",
+      "team1": "Manchester City FC",
+      "team2": "Everton FC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-03-03",
+      "time": "12:00",
+      "team1": "Arsenal FC",
+      "team2": "Crystal Palace FC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-03-03",
+      "time": "12:00",
+      "team1": "Leeds United FC",
+      "team2": "Hull City AFC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-03-03",
+      "time": "12:00",
+      "team1": "Sunderland AFC",
+      "team2": "Manchester United FC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-03-03",
+      "time": "12:00",
+      "team1": "Liverpool FC",
+      "team2": "Aston Villa FC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-03-03",
+      "time": "12:00",
+      "team1": "Brighton & Hove Albion FC",
+      "team2": "Fulham FC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-03-03",
+      "time": "12:00",
+      "team1": "Brentford FC",
+      "team2": "Ipswich Town FC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-03-03",
+      "time": "12:00",
+      "team1": "Chelsea FC",
+      "team2": "Coventry City FC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Leeds United FC",
+      "team2": "Brighton & Hove Albion FC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Tottenham Hotspur FC",
+      "team2": "Nottingham Forest FC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Crystal Palace FC",
+      "team2": "Fulham FC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Liverpool FC",
+      "team2": "Ipswich Town FC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Coventry City FC",
+      "team2": "Manchester City FC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "AFC Bournemouth",
+      "team2": "Newcastle United FC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Chelsea FC",
+      "team2": "Arsenal FC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Aston Villa FC",
+      "team2": "Hull City AFC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Manchester United FC",
+      "team2": "Everton FC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Sunderland AFC",
+      "team2": "Brentford FC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Brentford FC",
+      "team2": "AFC Bournemouth"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Brighton & Hove Albion FC",
+      "team2": "Coventry City FC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Manchester City FC",
+      "team2": "Manchester United FC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Ipswich Town FC",
+      "team2": "Crystal Palace FC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Arsenal FC",
+      "team2": "Sunderland AFC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Fulham FC",
+      "team2": "Liverpool FC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Hull City AFC",
+      "team2": "Chelsea FC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Nottingham Forest FC",
+      "team2": "Aston Villa FC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Everton FC",
+      "team2": "Tottenham Hotspur FC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Newcastle United FC",
+      "team2": "Leeds United FC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Sunderland AFC",
+      "team2": "Ipswich Town FC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Leeds United FC",
+      "team2": "Nottingham Forest FC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Manchester United FC",
+      "team2": "Hull City AFC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Chelsea FC",
+      "team2": "Fulham FC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Liverpool FC",
+      "team2": "Newcastle United FC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Coventry City FC",
+      "team2": "Arsenal FC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "AFC Bournemouth",
+      "team2": "Manchester City FC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Crystal Palace FC",
+      "team2": "Everton FC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Tottenham Hotspur FC",
+      "team2": "Brentford FC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Aston Villa FC",
+      "team2": "Brighton & Hove Albion FC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "Brighton & Hove Albion FC",
+      "team2": "Chelsea FC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "Fulham FC",
+      "team2": "Sunderland AFC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "Brentford FC",
+      "team2": "Leeds United FC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "Nottingham Forest FC",
+      "team2": "Liverpool FC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "Hull City AFC",
+      "team2": "Coventry City FC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "Arsenal FC",
+      "team2": "Aston Villa FC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "Ipswich Town FC",
+      "team2": "Manchester United FC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "Manchester City FC",
+      "team2": "Crystal Palace FC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "Newcastle United FC",
+      "team2": "Tottenham Hotspur FC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "Everton FC",
+      "team2": "AFC Bournemouth"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Chelsea FC",
+      "team2": "Manchester City FC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "AFC Bournemouth",
+      "team2": "Arsenal FC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Tottenham Hotspur FC",
+      "team2": "Hull City AFC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Manchester United FC",
+      "team2": "Crystal Palace FC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Everton FC",
+      "team2": "Brighton & Hove Albion FC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Nottingham Forest FC",
+      "team2": "Sunderland AFC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Newcastle United FC",
+      "team2": "Ipswich Town FC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Aston Villa FC",
+      "team2": "Coventry City FC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Brentford FC",
+      "team2": "Fulham FC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Leeds United FC",
+      "team2": "Liverpool FC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "Sunderland AFC",
+      "team2": "Newcastle United FC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "Brighton & Hove Albion FC",
+      "team2": "Nottingham Forest FC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "Coventry City FC",
+      "team2": "Manchester United FC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "Hull City AFC",
+      "team2": "AFC Bournemouth"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "Manchester City FC",
+      "team2": "Brentford FC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "Fulham FC",
+      "team2": "Everton FC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "Liverpool FC",
+      "team2": "Chelsea FC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "Arsenal FC",
+      "team2": "Tottenham Hotspur FC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "Crystal Palace FC",
+      "team2": "Aston Villa FC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "Ipswich Town FC",
+      "team2": "Leeds United FC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-05-08",
+      "time": "13:00",
+      "team1": "Manchester City FC",
+      "team2": "Liverpool FC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-05-08",
+      "time": "13:00",
+      "team1": "Leeds United FC",
+      "team2": "Arsenal FC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-05-08",
+      "time": "13:00",
+      "team1": "Fulham FC",
+      "team2": "Ipswich Town FC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-05-08",
+      "time": "13:00",
+      "team1": "Nottingham Forest FC",
+      "team2": "Crystal Palace FC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-05-08",
+      "time": "13:00",
+      "team1": "Brentford FC",
+      "team2": "Aston Villa FC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-05-08",
+      "time": "13:00",
+      "team1": "Newcastle United FC",
+      "team2": "Coventry City FC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-05-08",
+      "time": "13:00",
+      "team1": "Brighton & Hove Albion FC",
+      "team2": "Sunderland AFC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-05-08",
+      "time": "13:00",
+      "team1": "Tottenham Hotspur FC",
+      "team2": "Chelsea FC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-05-08",
+      "time": "13:00",
+      "team1": "Everton FC",
+      "team2": "Hull City AFC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-05-08",
+      "time": "13:00",
+      "team1": "AFC Bournemouth",
+      "team2": "Manchester United FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-05-15",
+      "time": "13:00",
+      "team1": "Hull City AFC",
+      "team2": "Fulham FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-05-15",
+      "time": "13:00",
+      "team1": "Manchester United FC",
+      "team2": "Leeds United FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-05-15",
+      "time": "13:00",
+      "team1": "Crystal Palace FC",
+      "team2": "Brighton & Hove Albion FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-05-15",
+      "time": "13:00",
+      "team1": "Aston Villa FC",
+      "team2": "Newcastle United FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-05-15",
+      "time": "13:00",
+      "team1": "Chelsea FC",
+      "team2": "Everton FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-05-15",
+      "time": "13:00",
+      "team1": "Coventry City FC",
+      "team2": "Tottenham Hotspur FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-05-15",
+      "time": "13:00",
+      "team1": "Sunderland AFC",
+      "team2": "AFC Bournemouth"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-05-15",
+      "time": "13:00",
+      "team1": "Liverpool FC",
+      "team2": "Brentford FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-05-15",
+      "time": "13:00",
+      "team1": "Ipswich Town FC",
+      "team2": "Manchester City FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-05-15",
+      "time": "13:00",
+      "team1": "Arsenal FC",
+      "team2": "Nottingham Forest FC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-05-23",
+      "time": "13:00",
+      "team1": "Brentford FC",
+      "team2": "Hull City AFC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-05-23",
+      "time": "13:00",
+      "team1": "Newcastle United FC",
+      "team2": "Crystal Palace FC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-05-23",
+      "time": "13:00",
+      "team1": "Tottenham Hotspur FC",
+      "team2": "Manchester United FC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-05-23",
+      "time": "13:00",
+      "team1": "Leeds United FC",
+      "team2": "Sunderland AFC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-05-23",
+      "time": "13:00",
+      "team1": "Brighton & Hove Albion FC",
+      "team2": "Liverpool FC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-05-23",
+      "time": "13:00",
+      "team1": "Nottingham Forest FC",
+      "team2": "Ipswich Town FC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-05-23",
+      "time": "13:00",
+      "team1": "AFC Bournemouth",
+      "team2": "Chelsea FC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-05-23",
+      "time": "13:00",
+      "team1": "Fulham FC",
+      "team2": "Coventry City FC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-05-23",
+      "time": "13:00",
+      "team1": "Everton FC",
+      "team2": "Arsenal FC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-05-23",
+      "time": "13:00",
+      "team1": "Manchester City FC",
+      "team2": "Aston Villa FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-05-30",
+      "time": "13:00",
+      "team1": "Ipswich Town FC",
+      "team2": "Everton FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-05-30",
+      "time": "13:00",
+      "team1": "Arsenal FC",
+      "team2": "Brighton & Hove Albion FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-05-30",
+      "time": "13:00",
+      "team1": "Liverpool FC",
+      "team2": "AFC Bournemouth"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-05-30",
+      "time": "13:00",
+      "team1": "Coventry City FC",
+      "team2": "Nottingham Forest FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-05-30",
+      "time": "13:00",
+      "team1": "Aston Villa FC",
+      "team2": "Tottenham Hotspur FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-05-30",
+      "time": "13:00",
+      "team1": "Hull City AFC",
+      "team2": "Newcastle United FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-05-30",
+      "time": "13:00",
+      "team1": "Manchester United FC",
+      "team2": "Fulham FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-05-30",
+      "time": "13:00",
+      "team1": "Sunderland AFC",
+      "team2": "Manchester City FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-05-30",
+      "time": "13:00",
+      "team1": "Chelsea FC",
+      "team2": "Brentford FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-05-30",
+      "time": "13:00",
+      "team1": "Crystal Palace FC",
+      "team2": "Leeds United FC"
+    }
+  ]
+}

--- a/2026-27/en.2.json
+++ b/2026-27/en.2.json
@@ -1,0 +1,3869 @@
+{
+  "name": "English Championship 2026/27",
+  "matches": [
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-14",
+      "time": "20:00",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-15",
+      "time": "12:30",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-15",
+      "time": "15:00",
+      "team1": "Norwich City FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-15",
+      "time": "15:00",
+      "team1": "Bristol City FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-15",
+      "time": "15:00",
+      "team1": "Middlesbrough FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-15",
+      "time": "15:00",
+      "team1": "Stoke City FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-15",
+      "time": "15:00",
+      "team1": "Charlton Athletic FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-15",
+      "time": "15:00",
+      "team1": "Portsmouth FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-15",
+      "time": "17:30",
+      "team1": "Sheffield United FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-16",
+      "time": "13:30",
+      "team1": "Watford FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-16",
+      "time": "16:00",
+      "team1": "Burnley FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 1",
+      "date": "2026-08-17",
+      "time": "20:00",
+      "team1": "Cardiff City FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-22",
+      "time": "15:00",
+      "team1": "Birmingham City FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-22",
+      "time": "15:00",
+      "team1": "Swansea City AFC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-22",
+      "time": "15:00",
+      "team1": "West Ham United FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-22",
+      "time": "15:00",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-22",
+      "time": "15:00",
+      "team1": "Derby County FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-22",
+      "time": "15:00",
+      "team1": "Preston North End FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-22",
+      "time": "15:00",
+      "team1": "Wrexham AFC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-22",
+      "time": "15:00",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-22",
+      "time": "15:00",
+      "team1": "Lincoln City FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-22",
+      "time": "15:00",
+      "team1": "Southampton FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-22",
+      "time": "15:00",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 2",
+      "date": "2026-08-22",
+      "time": "15:00",
+      "team1": "Millwall FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Norwich City FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Bristol City FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Southampton FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Charlton Athletic FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Derby County FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Cardiff City FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Middlesbrough FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Watford FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 3",
+      "date": "2026-08-29",
+      "time": "15:00",
+      "team1": "Wrexham AFC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-01",
+      "time": "19:45",
+      "team1": "Stoke City FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-01",
+      "time": "19:45",
+      "team1": "Preston North End FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-01",
+      "time": "19:45",
+      "team1": "West Ham United FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-01",
+      "time": "19:45",
+      "team1": "Lincoln City FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-01",
+      "time": "19:45",
+      "team1": "Sheffield United FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-01",
+      "time": "19:45",
+      "team1": "Portsmouth FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-01",
+      "time": "19:45",
+      "team1": "Birmingham City FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-01",
+      "time": "19:45",
+      "team1": "Swansea City AFC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-02",
+      "time": "19:45",
+      "team1": "Burnley FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-02",
+      "time": "19:45",
+      "team1": "Millwall FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-02",
+      "time": "19:45",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 4",
+      "date": "2026-09-02",
+      "time": "19:45",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "Sheffield United FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "Swansea City AFC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "Portsmouth FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "Preston North End FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "Stoke City FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "West Ham United FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "Burnley FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "Millwall FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "Birmingham City FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 5",
+      "date": "2026-09-05",
+      "time": "15:00",
+      "team1": "Lincoln City FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-09-08",
+      "time": "19:45",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-09-08",
+      "time": "19:45",
+      "team1": "Southampton FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-09-08",
+      "time": "19:45",
+      "team1": "Watford FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-09-08",
+      "time": "19:45",
+      "team1": "Cardiff City FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-09-08",
+      "time": "19:45",
+      "team1": "Middlesbrough FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-09-08",
+      "time": "19:45",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-09-08",
+      "time": "19:45",
+      "team1": "Bolton Wanderers FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-09-08",
+      "time": "19:45",
+      "team1": "Bristol City FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-09-09",
+      "time": "19:45",
+      "team1": "Derby County FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-09-09",
+      "time": "19:45",
+      "team1": "Wrexham AFC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-09-09",
+      "time": "19:45",
+      "team1": "Charlton Athletic FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 6",
+      "date": "2026-09-09",
+      "time": "19:45",
+      "team1": "Norwich City FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "Southampton FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "Preston North End FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "Derby County FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "Charlton Athletic FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "Watford FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "Swansea City AFC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "West Ham United FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "Middlesbrough FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 7",
+      "date": "2026-09-12",
+      "time": "15:00",
+      "team1": "Sheffield United FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Bristol City FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Wrexham AFC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Stoke City FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Burnley FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Millwall FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Norwich City FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Cardiff City FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Portsmouth FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Birmingham City FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 8",
+      "date": "2026-09-19",
+      "time": "15:00",
+      "team1": "Lincoln City FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "Sheffield United FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "Southampton FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "Swansea City AFC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "Watford FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "West Ham United FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "Charlton Athletic FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "Derby County FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "Preston North End FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 9",
+      "date": "2026-10-10",
+      "time": "15:00",
+      "team1": "Middlesbrough FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-10-13",
+      "time": "19:45",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-10-13",
+      "time": "19:45",
+      "team1": "Wrexham AFC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-10-13",
+      "time": "19:45",
+      "team1": "Millwall FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-10-13",
+      "time": "19:45",
+      "team1": "Cardiff City FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-10-13",
+      "time": "19:45",
+      "team1": "Burnley FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-10-13",
+      "time": "19:45",
+      "team1": "Bristol City FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-10-13",
+      "time": "19:45",
+      "team1": "Birmingham City FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-10-13",
+      "time": "19:45",
+      "team1": "Stoke City FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-10-14",
+      "time": "19:45",
+      "team1": "Portsmouth FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-10-14",
+      "time": "19:45",
+      "team1": "Lincoln City FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-10-14",
+      "time": "19:45",
+      "team1": "Norwich City FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 10",
+      "date": "2026-10-14",
+      "time": "19:45",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "Norwich City FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "Southampton FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "Burnley FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "Millwall FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "Bristol City FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "Birmingham City FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "Middlesbrough FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "Derby County FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "Watford FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "Swansea City AFC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 11",
+      "date": "2026-10-17",
+      "time": "15:00",
+      "team1": "Wrexham AFC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Cardiff City FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Sheffield United FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Stoke City FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Preston North End FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Lincoln City FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "West Ham United FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Charlton Athletic FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 12",
+      "date": "2026-10-24",
+      "time": "15:00",
+      "team1": "Portsmouth FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "West Ham United FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "Swansea City AFC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "Stoke City FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "Norwich City FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "Middlesbrough FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "Burnley FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "Millwall FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "Southampton FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "Lincoln City FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 13",
+      "date": "2026-10-31",
+      "time": "15:00",
+      "team1": "Sheffield United FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-11-03",
+      "time": "19:45",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-11-03",
+      "time": "19:45",
+      "team1": "Derby County FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-11-03",
+      "time": "19:45",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-11-03",
+      "time": "19:45",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-11-03",
+      "time": "19:45",
+      "team1": "Watford FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-11-03",
+      "time": "19:45",
+      "team1": "Birmingham City FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-11-03",
+      "time": "19:45",
+      "team1": "Portsmouth FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-11-03",
+      "time": "19:45",
+      "team1": "Preston North End FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-11-04",
+      "time": "19:45",
+      "team1": "Cardiff City FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-11-04",
+      "time": "19:45",
+      "team1": "Bristol City FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-11-04",
+      "time": "19:45",
+      "team1": "Wrexham AFC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 14",
+      "date": "2026-11-04",
+      "time": "19:45",
+      "team1": "Charlton Athletic FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Cardiff City FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Charlton Athletic FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Derby County FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Wrexham AFC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Watford FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Blackburn Rovers FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Preston North End FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Portsmouth FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Bristol City FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 15",
+      "date": "2026-11-07",
+      "time": "15:00",
+      "team1": "Birmingham City FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "Sheffield United FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "Swansea City AFC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "Middlesbrough FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "Southampton FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "Stoke City FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "Burnley FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "Norwich City FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "Lincoln City FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "Millwall FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "West Ham United FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 16",
+      "date": "2026-11-21",
+      "time": "15:00",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-11-24",
+      "time": "19:45",
+      "team1": "Cardiff City FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-11-24",
+      "time": "19:45",
+      "team1": "Middlesbrough FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-11-24",
+      "time": "19:45",
+      "team1": "Portsmouth FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-11-24",
+      "time": "19:45",
+      "team1": "Sheffield United FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-11-24",
+      "time": "19:45",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-11-24",
+      "time": "19:45",
+      "team1": "Charlton Athletic FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-11-24",
+      "time": "19:45",
+      "team1": "Bristol City FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-11-24",
+      "time": "19:45",
+      "team1": "Norwich City FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-11-25",
+      "time": "19:45",
+      "team1": "Watford FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-11-25",
+      "time": "19:45",
+      "team1": "Stoke City FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-11-25",
+      "time": "19:45",
+      "team1": "Bolton Wanderers FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 17",
+      "date": "2026-11-25",
+      "time": "19:45",
+      "team1": "Burnley FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "Wrexham AFC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "Millwall FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "Southampton FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "Birmingham City FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "Derby County FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "Lincoln City FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "Preston North End FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "West Ham United FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 18",
+      "date": "2026-11-28",
+      "time": "15:00",
+      "team1": "Swansea City AFC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Bristol City FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Cardiff City FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Sheffield United FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Norwich City FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Charlton Athletic FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Watford FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Portsmouth FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Stoke City FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Burnley FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 19",
+      "date": "2026-12-05",
+      "time": "15:00",
+      "team1": "Middlesbrough FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2026-12-08",
+      "time": "19:45",
+      "team1": "West Ham United FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2026-12-08",
+      "time": "19:45",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2026-12-08",
+      "time": "19:45",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2026-12-08",
+      "time": "19:45",
+      "team1": "Wrexham AFC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2026-12-08",
+      "time": "19:45",
+      "team1": "Millwall FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2026-12-08",
+      "time": "19:45",
+      "team1": "Swansea City AFC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2026-12-08",
+      "time": "19:45",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2026-12-08",
+      "time": "19:45",
+      "team1": "Birmingham City FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2026-12-09",
+      "time": "19:45",
+      "team1": "Southampton FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2026-12-09",
+      "time": "19:45",
+      "team1": "Preston North End FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2026-12-09",
+      "time": "19:45",
+      "team1": "Lincoln City FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 20",
+      "date": "2026-12-09",
+      "time": "19:45",
+      "team1": "Derby County FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Charlton Athletic FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "West Ham United FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Preston North End FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Stoke City FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Lincoln City FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Portsmouth FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Sheffield United FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 21",
+      "date": "2026-12-12",
+      "time": "15:00",
+      "team1": "Cardiff City FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "Middlesbrough FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "Bristol City FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "Norwich City FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "Millwall FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "Burnley FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "Derby County FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "Wrexham AFC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "Southampton FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "Birmingham City FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "Swansea City AFC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 22",
+      "date": "2026-12-19",
+      "time": "15:00",
+      "team1": "Watford FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Sheffield United FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Portsmouth FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "West Ham United FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Stoke City FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Cardiff City FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Lincoln City FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Preston North End FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 23",
+      "date": "2026-12-26",
+      "time": "15:00",
+      "team1": "Charlton Athletic FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2026-12-29",
+      "time": "19:45",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2026-12-29",
+      "time": "19:45",
+      "team1": "Derby County FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2026-12-29",
+      "time": "19:45",
+      "team1": "Swansea City AFC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2026-12-29",
+      "time": "19:45",
+      "team1": "Watford FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2026-12-29",
+      "time": "19:45",
+      "team1": "Southampton FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2026-12-29",
+      "time": "19:45",
+      "team1": "Norwich City FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2026-12-29",
+      "time": "19:45",
+      "team1": "Burnley FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2026-12-29",
+      "time": "19:45",
+      "team1": "Wrexham AFC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2026-12-29",
+      "time": "19:45",
+      "team1": "Birmingham City FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2026-12-29",
+      "time": "19:45",
+      "team1": "Middlesbrough FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2026-12-29",
+      "time": "19:45",
+      "team1": "Bristol City FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 24",
+      "date": "2026-12-29",
+      "time": "19:45",
+      "team1": "Millwall FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-01-01",
+      "time": "12:00",
+      "team1": "Middlesbrough FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-01-01",
+      "time": "12:00",
+      "team1": "Southampton FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-01-01",
+      "time": "12:00",
+      "team1": "Watford FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-01-01",
+      "time": "12:00",
+      "team1": "Burnley FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-01-01",
+      "time": "12:00",
+      "team1": "Derby County FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-01-01",
+      "time": "12:00",
+      "team1": "Birmingham City FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-01-01",
+      "time": "12:00",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-01-01",
+      "time": "12:00",
+      "team1": "Norwich City FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-01-01",
+      "time": "12:00",
+      "team1": "Swansea City AFC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-01-01",
+      "time": "12:00",
+      "team1": "Wrexham AFC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-01-01",
+      "time": "12:00",
+      "team1": "Millwall FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 25",
+      "date": "2027-01-01",
+      "time": "12:00",
+      "team1": "Bristol City FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "Stoke City FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "Charlton Athletic FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "Preston North End FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "Cardiff City FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "Lincoln City FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "Portsmouth FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "Sheffield United FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "West Ham United FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 26",
+      "date": "2027-01-16",
+      "time": "12:00",
+      "team1": "Blackburn Rovers FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Wrexham AFC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Preston North End FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Cardiff City FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Bristol City FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Derby County FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Portsmouth FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Charlton Athletic FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Birmingham City FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Watford FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "West Bromwich Albion FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 27",
+      "date": "2027-01-23",
+      "time": "12:00",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-01-26",
+      "time": "12:00",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-01-26",
+      "time": "12:00",
+      "team1": "Norwich City FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-01-26",
+      "time": "12:00",
+      "team1": "Lincoln City FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-01-26",
+      "time": "12:00",
+      "team1": "Sheffield United FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-01-26",
+      "time": "12:00",
+      "team1": "Southampton FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-01-26",
+      "time": "12:00",
+      "team1": "Millwall FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-01-26",
+      "time": "12:00",
+      "team1": "Stoke City FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-01-26",
+      "time": "12:00",
+      "team1": "Burnley FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-01-27",
+      "time": "12:00",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-01-27",
+      "time": "12:00",
+      "team1": "Swansea City AFC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-01-27",
+      "time": "12:00",
+      "team1": "West Ham United FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 28",
+      "date": "2027-01-27",
+      "time": "12:00",
+      "team1": "Middlesbrough FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "Burnley FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "Swansea City AFC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "Southampton FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "Millwall FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "Lincoln City FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "Stoke City FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "West Ham United FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "Middlesbrough FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "Sheffield United FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 29",
+      "date": "2027-01-30",
+      "time": "12:00",
+      "team1": "Norwich City FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Derby County FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Watford FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Preston North End FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Portsmouth FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Charlton Athletic FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Wrexham AFC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Cardiff City FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Birmingham City FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 30",
+      "date": "2027-02-06",
+      "time": "12:00",
+      "team1": "Bristol City FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-02-13",
+      "time": "12:00",
+      "team1": "Bristol City FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-02-13",
+      "time": "12:00",
+      "team1": "Queens Park Rangers FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-02-13",
+      "time": "12:00",
+      "team1": "Lincoln City FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-02-13",
+      "time": "12:00",
+      "team1": "Birmingham City FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-02-13",
+      "time": "12:00",
+      "team1": "Norwich City FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-02-13",
+      "time": "12:00",
+      "team1": "Cardiff City FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-02-13",
+      "time": "12:00",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-02-13",
+      "time": "12:00",
+      "team1": "Stoke City FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-02-13",
+      "time": "12:00",
+      "team1": "Wrexham AFC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-02-13",
+      "time": "12:00",
+      "team1": "Burnley FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-02-13",
+      "time": "12:00",
+      "team1": "Portsmouth FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 31",
+      "date": "2027-02-13",
+      "time": "12:00",
+      "team1": "Millwall FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-02-16",
+      "time": "12:00",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-02-16",
+      "time": "12:00",
+      "team1": "Sheffield United FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-02-16",
+      "time": "12:00",
+      "team1": "West Ham United FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-02-16",
+      "time": "12:00",
+      "team1": "Charlton Athletic FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-02-16",
+      "time": "12:00",
+      "team1": "Preston North End FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-02-16",
+      "time": "12:00",
+      "team1": "Watford FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-02-16",
+      "time": "12:00",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-02-16",
+      "time": "12:00",
+      "team1": "Derby County FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-02-17",
+      "time": "12:00",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-02-17",
+      "time": "12:00",
+      "team1": "Swansea City AFC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-02-17",
+      "time": "12:00",
+      "team1": "Southampton FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 32",
+      "date": "2027-02-17",
+      "time": "12:00",
+      "team1": "Middlesbrough FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "Southampton FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "Charlton Athletic FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "Swansea City AFC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "Sheffield United FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "Preston North End FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "Derby County FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "Middlesbrough FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "Watford FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "West Ham United FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 33",
+      "date": "2027-02-20",
+      "time": "12:00",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Queens Park Rangers FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Portsmouth FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Stoke City FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Norwich City FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Wrexham AFC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Bristol City FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Birmingham City FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Lincoln City FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Burnley FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Cardiff City FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 34",
+      "date": "2027-02-27",
+      "time": "12:00",
+      "team1": "Millwall FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-03-02",
+      "time": "12:00",
+      "team1": "Middlesbrough FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-03-02",
+      "time": "12:00",
+      "team1": "Norwich City FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-03-02",
+      "time": "12:00",
+      "team1": "Burnley FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-03-02",
+      "time": "12:00",
+      "team1": "Watford FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-03-02",
+      "time": "12:00",
+      "team1": "Charlton Athletic FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-03-02",
+      "time": "12:00",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-03-02",
+      "time": "12:00",
+      "team1": "Bristol City FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-03-02",
+      "time": "12:00",
+      "team1": "Cardiff City FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-03-03",
+      "time": "12:00",
+      "team1": "Portsmouth FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-03-03",
+      "time": "12:00",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-03-03",
+      "time": "12:00",
+      "team1": "Sheffield United FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 35",
+      "date": "2027-03-03",
+      "time": "12:00",
+      "team1": "Stoke City FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-03-06",
+      "time": "12:00",
+      "team1": "Derby County FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-03-06",
+      "time": "12:00",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-03-06",
+      "time": "12:00",
+      "team1": "Southampton FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-03-06",
+      "time": "12:00",
+      "team1": "Wrexham AFC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-03-06",
+      "time": "12:00",
+      "team1": "Swansea City AFC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-03-06",
+      "time": "12:00",
+      "team1": "Preston North End FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-03-06",
+      "time": "12:00",
+      "team1": "Lincoln City FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-03-06",
+      "time": "12:00",
+      "team1": "Millwall FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-03-06",
+      "time": "12:00",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-03-06",
+      "time": "12:00",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-03-06",
+      "time": "12:00",
+      "team1": "Birmingham City FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 36",
+      "date": "2027-03-06",
+      "time": "12:00",
+      "team1": "West Ham United FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Watford FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Burnley FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Portsmouth FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Middlesbrough FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Sheffield United FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Bristol City FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Charlton Athletic FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Stoke City FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Norwich City FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Cardiff City FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 37",
+      "date": "2027-03-13",
+      "time": "12:00",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-03-16",
+      "time": "12:00",
+      "team1": "Preston North End FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-03-16",
+      "time": "12:00",
+      "team1": "Swansea City AFC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-03-16",
+      "time": "12:00",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-03-16",
+      "time": "12:00",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-03-16",
+      "time": "12:00",
+      "team1": "Wrexham AFC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-03-16",
+      "time": "12:00",
+      "team1": "Lincoln City FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-03-16",
+      "time": "12:00",
+      "team1": "Derby County FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-03-16",
+      "time": "12:00",
+      "team1": "Southampton FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-03-17",
+      "time": "12:00",
+      "team1": "West Ham United FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-03-17",
+      "time": "12:00",
+      "team1": "Millwall FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-03-17",
+      "time": "12:00",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 38",
+      "date": "2027-03-17",
+      "time": "12:00",
+      "team1": "Birmingham City FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 39",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Swansea City AFC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 39",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Millwall FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 39",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Wrexham AFC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 39",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Bristol City FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 39",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Watford FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 39",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Southampton FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 39",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Birmingham City FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 39",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Burnley FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 39",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Middlesbrough FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 39",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 39",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Norwich City FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 39",
+      "date": "2027-03-20",
+      "time": "12:00",
+      "team1": "Derby County FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 40",
+      "date": "2027-04-03",
+      "time": "13:00",
+      "team1": "Stoke City FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 40",
+      "date": "2027-04-03",
+      "time": "13:00",
+      "team1": "Portsmouth FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 40",
+      "date": "2027-04-03",
+      "time": "13:00",
+      "team1": "Cardiff City FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 40",
+      "date": "2027-04-03",
+      "time": "13:00",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 40",
+      "date": "2027-04-03",
+      "time": "13:00",
+      "team1": "Charlton Athletic FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 40",
+      "date": "2027-04-03",
+      "time": "13:00",
+      "team1": "West Ham United FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 40",
+      "date": "2027-04-03",
+      "time": "13:00",
+      "team1": "Lincoln City FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 40",
+      "date": "2027-04-03",
+      "time": "13:00",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 40",
+      "date": "2027-04-03",
+      "time": "13:00",
+      "team1": "Sheffield United FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 40",
+      "date": "2027-04-03",
+      "time": "13:00",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 40",
+      "date": "2027-04-03",
+      "time": "13:00",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 40",
+      "date": "2027-04-03",
+      "time": "13:00",
+      "team1": "Preston North End FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 41",
+      "date": "2027-04-06",
+      "time": "13:00",
+      "team1": "Lincoln City FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 41",
+      "date": "2027-04-06",
+      "time": "13:00",
+      "team1": "Millwall FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 41",
+      "date": "2027-04-06",
+      "time": "13:00",
+      "team1": "West Ham United FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 41",
+      "date": "2027-04-06",
+      "time": "13:00",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 41",
+      "date": "2027-04-06",
+      "time": "13:00",
+      "team1": "Stoke City FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 41",
+      "date": "2027-04-06",
+      "time": "13:00",
+      "team1": "Portsmouth FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 41",
+      "date": "2027-04-06",
+      "time": "13:00",
+      "team1": "Swansea City AFC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 41",
+      "date": "2027-04-06",
+      "time": "13:00",
+      "team1": "Burnley FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 41",
+      "date": "2027-04-07",
+      "time": "13:00",
+      "team1": "Preston North End FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 41",
+      "date": "2027-04-07",
+      "time": "13:00",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 41",
+      "date": "2027-04-07",
+      "time": "13:00",
+      "team1": "Birmingham City FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 41",
+      "date": "2027-04-07",
+      "time": "13:00",
+      "team1": "Sheffield United FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 42",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Wrexham AFC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 42",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 42",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Watford FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 42",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 42",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 42",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Norwich City FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 42",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Middlesbrough FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 42",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Cardiff City FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 42",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Southampton FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 42",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Charlton Athletic FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 42",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Bristol City FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 42",
+      "date": "2027-04-10",
+      "time": "13:00",
+      "team1": "Derby County FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 43",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "Preston North End FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 43",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "Portsmouth FC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 43",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "Birmingham City FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 43",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "Stoke City FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 43",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "Lincoln City FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 43",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Middlesbrough FC"
+    },
+    {
+      "round": "Matchday 43",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 43",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "West Ham United FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 43",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "Burnley FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 43",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "Millwall FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 43",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "Swansea City AFC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 43",
+      "date": "2027-04-17",
+      "time": "13:00",
+      "team1": "Sheffield United FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 44",
+      "date": "2027-04-20",
+      "time": "13:00",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 44",
+      "date": "2027-04-20",
+      "time": "13:00",
+      "team1": "Norwich City FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 44",
+      "date": "2027-04-20",
+      "time": "13:00",
+      "team1": "Middlesbrough FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 44",
+      "date": "2027-04-20",
+      "time": "13:00",
+      "team1": "Derby County FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 44",
+      "date": "2027-04-20",
+      "time": "13:00",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 44",
+      "date": "2027-04-20",
+      "time": "13:00",
+      "team1": "Wrexham AFC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 44",
+      "date": "2027-04-20",
+      "time": "13:00",
+      "team1": "Southampton FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 44",
+      "date": "2027-04-20",
+      "time": "13:00",
+      "team1": "Charlton Athletic FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 44",
+      "date": "2027-04-21",
+      "time": "13:00",
+      "team1": "Bristol City FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 44",
+      "date": "2027-04-21",
+      "time": "13:00",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 44",
+      "date": "2027-04-21",
+      "time": "13:00",
+      "team1": "Cardiff City FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 44",
+      "date": "2027-04-21",
+      "time": "13:00",
+      "team1": "Watford FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 45",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Watford FC",
+      "team2": "Birmingham City FC"
+    },
+    {
+      "round": "Matchday 45",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Middlesbrough FC",
+      "team2": "West Ham United FC"
+    },
+    {
+      "round": "Matchday 45",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Stoke City FC",
+      "team2": "Lincoln City FC"
+    },
+    {
+      "round": "Matchday 45",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Burnley FC",
+      "team2": "Southampton FC"
+    },
+    {
+      "round": "Matchday 45",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Bolton Wanderers FC",
+      "team2": "Swansea City AFC"
+    },
+    {
+      "round": "Matchday 45",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Sheffield United FC",
+      "team2": "Millwall FC"
+    },
+    {
+      "round": "Matchday 45",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Wolverhampton Wanderers FC",
+      "team2": "Queens Park Rangers FC"
+    },
+    {
+      "round": "Matchday 45",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Bristol City FC",
+      "team2": "Derby County FC"
+    },
+    {
+      "round": "Matchday 45",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Charlton Athletic FC",
+      "team2": "Wrexham AFC"
+    },
+    {
+      "round": "Matchday 45",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Norwich City FC",
+      "team2": "Blackburn Rovers FC"
+    },
+    {
+      "round": "Matchday 45",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Cardiff City FC",
+      "team2": "West Bromwich Albion FC"
+    },
+    {
+      "round": "Matchday 45",
+      "date": "2027-04-24",
+      "time": "13:00",
+      "team1": "Portsmouth FC",
+      "team2": "Preston North End FC"
+    },
+    {
+      "round": "Matchday 46",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "Queens Park Rangers FC",
+      "team2": "Norwich City FC"
+    },
+    {
+      "round": "Matchday 46",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "West Ham United FC",
+      "team2": "Portsmouth FC"
+    },
+    {
+      "round": "Matchday 46",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "West Bromwich Albion FC",
+      "team2": "Bolton Wanderers FC"
+    },
+    {
+      "round": "Matchday 46",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "Southampton FC",
+      "team2": "Sheffield United FC"
+    },
+    {
+      "round": "Matchday 46",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "Birmingham City FC",
+      "team2": "Burnley FC"
+    },
+    {
+      "round": "Matchday 46",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "Millwall FC",
+      "team2": "Stoke City FC"
+    },
+    {
+      "round": "Matchday 46",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "Wrexham AFC",
+      "team2": "Bristol City FC"
+    },
+    {
+      "round": "Matchday 46",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "Blackburn Rovers FC",
+      "team2": "Watford FC"
+    },
+    {
+      "round": "Matchday 46",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "Lincoln City FC",
+      "team2": "Charlton Athletic FC"
+    },
+    {
+      "round": "Matchday 46",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "Preston North End FC",
+      "team2": "Cardiff City FC"
+    },
+    {
+      "round": "Matchday 46",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "Derby County FC",
+      "team2": "Wolverhampton Wanderers FC"
+    },
+    {
+      "round": "Matchday 46",
+      "date": "2027-05-01",
+      "time": "13:00",
+      "team1": "Swansea City AFC",
+      "team2": "Middlesbrough FC"
+    }
+  ]
+}


### PR DESCRIPTION
Used existing .txt files for 2026-27 premiership (openfootball/england/2026-27/1-premierleague.txt) and championship  (openfootball/england/2026-27/2-championship.txt) data to generate the equivalent 2026-27 football.json files under a new 2026-27/ directory.

I contributed this as I plan to use the json files in other projects - I made a web app that fetches this data at https://berenrj.github.io/football-fixture-acca-builder/ , however I noticed that although the season has started, most of these 2026-27 json files don't yet exist.